### PR TITLE
chore(stats): optimize stats.controller.ts by using common cache getburninfo

### DIFF
--- a/src/module.api/stats.controller.ts
+++ b/src/module.api/stats.controller.ts
@@ -11,6 +11,7 @@ import { BlockchainInfo } from '@defichain/jellyfish-api-core/dist/category/bloc
 import { getBlockSubsidy } from '@src/module.api/subsidy'
 import { BlockSubsidy } from '@defichain/jellyfish-network'
 import { BurnInfo } from '@defichain/jellyfish-api-core/dist/category/account'
+import { GetLoanInfoResult } from '@defichain/jellyfish-api-core/dist/category/loan'
 
 @Controller('/stats')
 export class StatsController {
@@ -29,7 +30,7 @@ export class StatsController {
   async get (): Promise<StatsData> {
     const block = requireValue(await this.blockMapper.getHighest(), 'block')
     const burned = await this.cachedGet('burned', this.getBurned.bind(this), 1806)
-    const burnedTotal = await this.cachedGet('Controller.supply.getBurnedTotal', this.getBurnedTotal.bind(this), 1806)
+    const burnedTotal = await this.cachedGet('Controller.supply.getBurnedTotal', this.getBurnedTotal.bind(this), 1899)
     return {
       count: {
         ...await this.cachedGet('count', this.getCount.bind(this), 1801),
@@ -42,7 +43,7 @@ export class StatsController {
       tvl: await this.cachedGet('tvl', this.getTVL.bind(this), 310),
       price: await this.cachedGet('price', this.getPrice.bind(this), 220),
       masternodes: await this.cachedGet('masternodes', this.getMasternodes.bind(this), 325),
-      loan: await this.cachedGet('loan', this.getLoan.bind(this), 299),
+      loan: await this.getLoan(),
       emission: await this.cachedGet('emission', this.getEmission.bind(this), 1750),
       net: await this.cachedGet('net', this.getNet.bind(this), 1830),
       blockchain: {
@@ -69,10 +70,16 @@ export class StatsController {
   }
 
   @Get('/burn')
-  async getBurn (): Promise<BurnInfo> {
-    return await this.cachedGet('Controller.burn.getBurnInfo', async () => {
+  async getBurnInfo (): Promise<BurnInfo> {
+    return await this.cachedGet('Controller.stats.getBurnInfo', async () => {
       return await this.rpcClient.account.getBurnInfo()
-    }, 123)
+    }, 666)
+  }
+
+  async getLoanInfo (): Promise<GetLoanInfoResult> {
+    return await this.cachedGet('Controller.stats.getLoanInfo', async () => {
+      return await this.rpcClient.loan.getLoanInfo()
+    }, 299)
   }
 
   private async cachedGet<T> (field: string, fetch: () => Promise<T>, ttl: number): Promise<T> {
@@ -128,7 +135,7 @@ export class StatsController {
   }
 
   private async getBurned (): Promise<StatsData['burned']> {
-    const burnInfo = await this.rpcClient.account.getBurnInfo()
+    const burnInfo = await this.getBurnInfo()
 
     const utxo = burnInfo.amount
     const account = findTokenBalance(burnInfo.tokens, 'DFI')
@@ -156,7 +163,7 @@ export class StatsController {
   private async getBurnedTotal (): Promise<BigNumber> {
     const address = '76a914f7874e8821097615ec345f74c7e5bcf61b12e2ee88ac'
     const tokens = await this.rpcClient.account.getAccount(address)
-    const burnInfo = await this.rpcClient.account.getBurnInfo()
+    const burnInfo = await this.getBurnInfo()
 
     const utxo = burnInfo.amount
     const account = findTokenBalance(tokens, 'DFI')
@@ -200,7 +207,7 @@ export class StatsController {
   }
 
   private async getLoan (): Promise<StatsData['loan']> {
-    const info = await this.rpcClient.loan.getLoanInfo()
+    const info = await this.getLoanInfo()
 
     return {
       count: {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Optimize expensive stats.controller.ts calls by using common cache getburninfo and getloaninfo for operations.