### PR TITLE
chore(cache): reduce semaphore cache concurrency to reduce locking

### DIFF
--- a/src/module.api/cache/semaphore.cache.spec.ts
+++ b/src/module.api/cache/semaphore.cache.spec.ts
@@ -14,7 +14,7 @@ beforeAll(async () => {
   cache = testing.get(SemaphoreCache)
 })
 
-it('should run twice with they same key, due to concurrency of 2', async () => {
+it('should run one with they same key, due to concurrency of 1', async () => {
   let counter = 0
 
   async function fetch (): Promise<string> {
@@ -31,7 +31,7 @@ it('should run twice with they same key, due to concurrency of 2', async () => {
     cache.get('collide-1', fetch)
   ])
 
-  expect(counter).toStrictEqual(2)
+  expect(counter).toStrictEqual(1)
 })
 
 it('key should not collide', async () => {

--- a/src/module.api/cache/semaphore.cache.ts
+++ b/src/module.api/cache/semaphore.cache.ts
@@ -5,7 +5,7 @@ import { Cache } from 'cache-manager'
 
 @Injectable()
 export class SemaphoreCache {
-  static MAX_CONCURRENCY = 2
+  static MAX_CONCURRENCY = 1
   static TIMEOUT = 45000
 
   protected readonly cache: GlobalCache


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

Due to higher than normal back pressure on defid, this PR reduces semaphore cache concurrency to 1 to reduce upstream back pressure.