### PR TITLE
chore(memory): increase node heap size to 4gb

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:16-alpine3.13
+ENV NODE_OPTIONS="--max-old-space-size=4096"
 
 # add curl for docker healthcheck capability
 RUN apk --no-cache add curl


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:

On high trafficked whale instances the node heap limit of `2 gb` isn't enough.