### PR TITLE
chore(whale-api-client): Default whale api client to v0 and let url be optional

### DIFF
--- a/packages/whale-api-client/__tests__/stub.client.ts
+++ b/packages/whale-api-client/__tests__/stub.client.ts
@@ -8,7 +8,7 @@ import AbortController from 'abort-controller'
  */
 export class StubWhaleApiClient extends WhaleApiClient {
   constructor (readonly service: StubService) {
-    super({ url: 'not required for stub service' })
+    super({})
   }
 
   async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {
@@ -16,10 +16,9 @@ export class StubWhaleApiClient extends WhaleApiClient {
       throw new Error('StubService is not yet started.')
     }
 
-    const version = this.options.version as string
     const res = await this.service.app.inject({
       method: method,
-      url: `/${version}/regtest/${path}`,
+      url: `/v0.0/regtest/${path}`,
       payload: body,
       headers: method !== 'GET' ? { 'Content-Type': 'application/json' } : {}
     })
@@ -43,7 +42,7 @@ export class StubWhaleRpcClient extends WhaleRpcClient {
 
     const res = await this.service.app.inject({
       method: 'POST',
-      url: '/v0/regtest/rpc',
+      url: '/v0.0/regtest/rpc',
       payload: body,
       headers: { 'Content-Type': 'application/json' }
     })

--- a/packages/whale-api-client/__tests__/stub.client.ts
+++ b/packages/whale-api-client/__tests__/stub.client.ts
@@ -1,6 +1,5 @@
 import { Method, ResponseAsString, WhaleApiClient, WhaleRpcClient } from '../src'
 import { StubService } from './stub.service'
-import version from '../src/version'
 import AbortController from 'abort-controller'
 
 /**
@@ -44,7 +43,7 @@ export class StubWhaleRpcClient extends WhaleRpcClient {
 
     const res = await this.service.app.inject({
       method: 'POST',
-      url: `/${version}/regtest/rpc`,
+      url: '/v0/regtest/rpc',
       payload: body,
       headers: { 'Content-Type': 'application/json' }
     })

--- a/packages/whale-api-client/package.json
+++ b/packages/whale-api-client/package.json
@@ -9,7 +9,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "./prebuild && tsc"
+    "build": "tsc"
   },
   "dependencies": {
     "@defichain/jellyfish-api-jsonrpc": "^2.45.1",

--- a/packages/whale-api-client/prebuild
+++ b/packages/whale-api-client/prebuild
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-node -p "'export default \'v' + require('./package.json').version.replace(/\.\d+$/, '') + '\''" > src/version.ts

--- a/packages/whale-api-client/src/version.ts
+++ b/packages/whale-api-client/src/version.ts
@@ -1,2 +1,0 @@
-/* eslint-disable import/no-default-export */
-export default 'v0.0'

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -80,6 +80,7 @@ export class WhaleApiClient {
     protected readonly options: WhaleApiClientOptions
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options }
+    this.options.url = this.options.url?.replace(/\/$/, '')
   }
 
   /**

--- a/packages/whale-api-client/src/whale.api.client.ts
+++ b/packages/whale-api-client/src/whale.api.client.ts
@@ -1,7 +1,6 @@
 import 'url-search-params-polyfill'
 import AbortController from 'abort-controller'
 import fetch from 'cross-fetch'
-import version from './version'
 import { raiseIfError, WhaleClientException, WhaleClientTimeoutException } from './errors'
 import { ApiPagedResponse, WhaleApiResponse } from './whale.api.response'
 import { Address } from './api/address'
@@ -22,7 +21,7 @@ import { Loan } from './api/loan'
  * WhaleApiClient Options
  */
 export interface WhaleApiClientOptions {
-  url: string
+  url?: string
 
   /**
    * Millis before request is aborted.
@@ -48,7 +47,7 @@ export interface WhaleApiClientOptions {
 const DEFAULT_OPTIONS: WhaleApiClientOptions = {
   url: 'https://ocean.defichain.com',
   timeout: 60000,
-  version: version,
+  version: 'v0',
   network: 'mainnet'
 }
 
@@ -81,7 +80,6 @@ export class WhaleApiClient {
     protected readonly options: WhaleApiClientOptions
   ) {
     this.options = { ...DEFAULT_OPTIONS, ...options }
-    this.options.url = this.options.url.replace(/\/$/, '')
   }
 
   /**
@@ -160,7 +158,7 @@ export class WhaleApiClient {
    */
   async requestAsString (method: Method, path: string, body?: string): Promise<ResponseAsString> {
     const { url: urlString, version, network, timeout } = this.options
-    const url = `${urlString}/${version as string}/${network as string}/${path}`
+    const url = `${urlString as string}/${version as string}/${network as string}/${path}`
 
     const controller = new AbortController()
     const id = setTimeout(() => controller.abort(), timeout)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it:
Currently WhaleApiClient options version default to the current npm release version. I think to ensure forever backward compatibility for users, we should default to v0.

#### Which issue(s) does this PR fixes?:
<!--
(Optional) Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/JellyfishSDK/whale/issues/979

#### Additional comments?:
